### PR TITLE
Async helpers on collections and sequences

### DIFF
--- a/Sources/InfomaniakCore/Extensions/Collection+Safe.swift
+++ b/Sources/InfomaniakCore/Extensions/Collection+Safe.swift
@@ -1,0 +1,26 @@
+/*
+ Infomaniak Core - iOS
+ Copyright (C) 2023 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+extension Collection {
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    subscript(safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Sources/InfomaniakCore/Extensions/Sequence+Async.swift
+++ b/Sources/InfomaniakCore/Extensions/Sequence+Async.swift
@@ -1,0 +1,45 @@
+/*
+ Infomaniak Core - iOS
+ Copyright (C) 2023 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+extension Sequence {
+    /// Map that support swift concurrency
+    func asyncMap<T>(
+        _ transform: (Element) async throws -> T
+    ) async rethrows -> [T] {
+        var values = [T]()
+
+        for element in self {
+            try await values.append(transform(element))
+        }
+
+        return values
+    }
+}
+
+extension Sequence {
+    /// ForEach that support swift concurrency
+    func asyncForEach(
+        _ operation: (Element) async throws -> Void
+    ) async rethrows {
+        for element in self {
+            try await operation(element)
+        }
+    }
+}

--- a/Tests/InfomaniakCoreTests/XCTestManifests.swift
+++ b/Tests/InfomaniakCoreTests/XCTestManifests.swift
@@ -19,18 +19,61 @@
 import XCTest
 @testable import InfomaniakCore
 
-final class InfomaniakCoreTests: XCTestCase {
-    func testExample() throws {
+final class CollectionTests: XCTestCase {
+    func testSafeIndexSuccess() {
         // GIVEN
-        let expectedCode = 1337
-        let error = InfomaniakError.serverError(statusCode: expectedCode)
+        let shortArray = [1]
+        
+        // WHEN
+        let fetched = shortArray[safe: 0]
         
         // THEN
-        switch error {
-        case .serverError(statusCode: let code):
-            XCTAssertEqual(code, expectedCode)
-        case .apiError(_):
-            XCTFail("unexpected")
+        XCTAssertEqual(fetched, 1)
+    }
+    
+    func testSafeIndexNil() {
+        // GIVEN
+        let shortArray = [1]
+        
+        // WHEN
+        let fetched = shortArray[safe: 1]
+        
+        // THEN
+        XCTAssertNil(fetched)
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class SequenceTests: XCTestCase {
+    
+    private func someAsyncFunc(input: Int) async -> Bool {
+        try! await Task.sleep(nanoseconds: 100)
+        return input > 2
+    }
+    
+    func testAsyncMap() async {
+        // GIVEN
+        let array = [1, 2, 3, 4, 5]
+        
+        // WHEN
+        let fetched = await array.asyncMap { await someAsyncFunc(input: $0) }
+        
+        // THEN
+        XCTAssertEqual(fetched, [false, false, true, true, true])
+    }
+    
+    func testAsyncForEach () async {
+        // GIVEN
+        let array = [1, 2, 3, 4, 5]
+        var callCount = 0
+        
+        // WHEN
+        await array.asyncForEach { _ in
+            try! await Task.sleep(nanoseconds: 100)
+            callCount += 1
         }
+        
+        // THEN
+        XCTAssertEqual(array.count, callCount)
     }
 }


### PR DESCRIPTION
## Abstract

Added .asyncMap .asyncForEach
Also added a safe access subscript for arrays
UT included
UT pass on every platform (mattomo fails to build for watchOS)

Linked to this PR : https://github.com/Infomaniak/ios-kMail/pull/758

