### PR TITLE
feat: Sendable collections improvements

### DIFF
--- a/Sources/InfomaniakCore/Asynchronous/SendableArray.swift
+++ b/Sources/InfomaniakCore/Asynchronous/SendableArray.swift
@@ -96,4 +96,16 @@ public final class SendableArray<T>: @unchecked Sendable {
             }
         }
     }
+    
+    public func removeAll(keepCapacity: Bool = false) {
+        lock.sync {
+            return content.removeAll(keepingCapacity: keepCapacity)
+        }
+    }
+    
+    public func removeAll(where shouldBeRemoved: (T) throws -> Bool) rethrows {
+        try lock.sync {
+            return try content.removeAll(where: shouldBeRemoved)
+        }
+    }
 }

--- a/Sources/InfomaniakCore/Asynchronous/SendableDictionary.swift
+++ b/Sources/InfomaniakCore/Asynchronous/SendableDictionary.swift
@@ -31,12 +31,9 @@ public final class SendableDictionary<T: Hashable, U>: @unchecked Sendable {
     }
 
     public var count: Int {
-        var buffer: Int!
         lock.sync {
-            buffer = content.count
+            return content.count
         }
-
-        return buffer
     }
 
     public var values: Dictionary<T, U>.Values {

--- a/Sources/InfomaniakCore/Asynchronous/SendableDictionary.swift
+++ b/Sources/InfomaniakCore/Asynchronous/SendableDictionary.swift
@@ -73,4 +73,10 @@ public final class SendableDictionary<T: Hashable, U>: @unchecked Sendable {
             setValue(newValue, for: key)
         }
     }
+
+    public func removeAll(keepCapacity: Bool = false) {
+        lock.sync {
+            return content.removeAll(keepingCapacity: keepCapacity)
+        }
+    }
 }

--- a/Tests/InfomaniakCoreTests/UTCollectionTests.swift
+++ b/Tests/InfomaniakCoreTests/UTCollectionTests.swift
@@ -129,4 +129,21 @@ final class UTSendableDictionary: XCTestCase {
         // THEN
         XCTAssertEqual(collection.count, 2)
     }
+    
+    func testRemoveAll() async {
+        // GIVEN
+        let collection = SendableDictionary<String, Int>()
+        collection.setValue(1, for: "a")
+        collection.setValue(2, for: "b")
+        
+        // WHEN
+        let t = Task.detached {
+            collection.removeAll()
+        }
+        
+        _ = await t.result
+        
+        // THEN
+        XCTAssertEqual(collection.count, 0)
+    }
 }

--- a/Tests/InfomaniakCoreTests/UTCollectionTests.swift
+++ b/Tests/InfomaniakCoreTests/UTCollectionTests.swift
@@ -109,7 +109,7 @@ final class UTSendableArray: XCTestCase {
         _ = await t.result
 
         // THEN
-        XCTAssertEqual(collection.count, 0)
+        XCTAssertTrue(collection.isEmpty)
     }
 
     func testRemoveAllWhere() async {
@@ -127,7 +127,7 @@ final class UTSendableArray: XCTestCase {
         _ = await t.result
 
         // THEN
-        XCTAssertEqual(collection.values.contains("b"), false)
+        XCTAssertFalse(collection.values.contains("b"))
     }
 }
 
@@ -179,6 +179,6 @@ final class UTSendableDictionary: XCTestCase {
         _ = await t.result
 
         // THEN
-        XCTAssertEqual(collection.count, 0)
+        XCTAssertTrue(collection.values.isEmpty)
     }
 }

--- a/Tests/InfomaniakCoreTests/UTCollectionTests.swift
+++ b/Tests/InfomaniakCoreTests/UTCollectionTests.swift
@@ -94,6 +94,41 @@ final class UTSendableArray: XCTestCase {
         // THEN
         XCTAssertEqual(collection.count, 2)
     }
+
+    func testRemoveAll() async {
+        // GIVEN
+        let collection = SendableArray<String>()
+        collection.append("a")
+        collection.append("b")
+
+        // WHEN
+        let t = Task.detached {
+            collection.removeAll()
+        }
+
+        _ = await t.result
+
+        // THEN
+        XCTAssertEqual(collection.count, 0)
+    }
+
+    func testRemoveAllWhere() async {
+        // GIVEN
+        let collection = SendableArray<String>()
+        collection.append("a")
+        collection.append("b")
+        collection.append("c")
+
+        // WHEN
+        let t = Task.detached {
+            collection.removeAll(where: { $0 == "b" })
+        }
+
+        _ = await t.result
+
+        // THEN
+        XCTAssertEqual(collection.values.contains("b"), false)
+    }
 }
 
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
@@ -129,20 +164,20 @@ final class UTSendableDictionary: XCTestCase {
         // THEN
         XCTAssertEqual(collection.count, 2)
     }
-    
+
     func testRemoveAll() async {
         // GIVEN
         let collection = SendableDictionary<String, Int>()
         collection.setValue(1, for: "a")
         collection.setValue(2, for: "b")
-        
+
         // WHEN
         let t = Task.detached {
             collection.removeAll()
         }
-        
+
         _ = await t.result
-        
+
         // THEN
         XCTAssertEqual(collection.count, 0)
     }


### PR DESCRIPTION
I chose to not reimplement the whole `RangeReplaceableCollection` protocol but rather add methods when needed.