### PR TITLE
fix(share_extension): copy instead of move, as might not be able to move

### DIFF
--- a/Sources/InfomaniakCore/ItemProviderRepresentation/ItemProviderURLRepresentation.swift
+++ b/Sources/InfomaniakCore/ItemProviderRepresentation/ItemProviderURLRepresentation.swift
@@ -113,7 +113,7 @@ public final class ItemProviderURLRepresentation: NSObject, ProgressResultable {
         let targetURL = try URL.temporaryUniqueFolderURL()
             .appendingPathComponent(fileName)
 
-        try fileManager.moveItem(at: url, to: targetURL)
+        try fileManager.copyItem(at: url, to: targetURL)
 
         completionProgress.completedUnitCount += Self.progressStep
         flowToAsync.sendSuccess(targetURL)

--- a/Sources/InfomaniakCore/ItemProviderRepresentation/ItemProviderZipRepresentation.swift
+++ b/Sources/InfomaniakCore/ItemProviderRepresentation/ItemProviderZipRepresentation.swift
@@ -86,7 +86,7 @@ public final class ItemProviderZipRepresentation: NSObject, ProgressResultable {
                     let fileName = path.lastPathComponent // Not empty as comes from the name of a system folder
                     let targetURL = tmpDirectoryURL.appendingPathComponent(fileName).appendingPathExtension(for: UTI.zip)
 
-                    try self.fileManager.moveItem(at: zipURL, to: targetURL)
+                    try self.fileManager.copyItem(at: zipURL, to: targetURL)
                     
                     completionProgress.completedUnitCount += Self.progressStep
                     self.flowToAsync.sendSuccess(targetURL)


### PR DESCRIPTION
This fix the behaviour for ProCreate file exporting