### PR TITLE
fix: Priority inversion could happen with TolerantDispatchGroup

### DIFF
--- a/Sources/InfomaniakCore/Asynchronous/TolerantDispatchGroup.swift
+++ b/Sources/InfomaniakCore/Asynchronous/TolerantDispatchGroup.swift
@@ -20,12 +20,12 @@ import CocoaLumberjackSwift
 import Foundation
 
 public final class TolerantDispatchGroup {
-    private let syncQueue = DispatchQueue(label: "com.infomaniak.TolerantDispatchGroup")
+    let syncQueue: DispatchQueue
     private let dispatchGroup = DispatchGroup()
     private var callBalancer = 0
 
-    public init() {
-        // Meta: Keep Sonar Cloud happy
+    public init(qos: DispatchQoS = .default) {
+        syncQueue = DispatchQueue(label: "com.infomaniak.TolerantDispatchGroup", qos: qos)
     }
     
     public func enter() {

--- a/Tests/InfomaniakCoreTests/UTTolerantDispatchGroup.swift
+++ b/Tests/InfomaniakCoreTests/UTTolerantDispatchGroup.swift
@@ -16,8 +16,14 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import InfomaniakCore
+@testable import InfomaniakCore
 import XCTest
+
+extension DispatchQoS: CaseIterable {
+    public static var allCases: [DispatchQoS] {
+        [.background, .utility, .default, .userInitiated, .userInteractive, .unspecified]
+    }
+}
 
 final class UTTolerantDispatchGroup: XCTestCase {
     func testCanInit() {
@@ -26,5 +32,29 @@ final class UTTolerantDispatchGroup: XCTestCase {
 
         // THEN
         XCTAssertNotNil(dispatchGroup)
+    }
+
+    func testPriorityDefault() {
+        // WHEN
+        let dispatchGroup = TolerantDispatchGroup()
+
+        // THEN
+        XCTAssertNotNil(dispatchGroup)
+        XCTAssertEqual(dispatchGroup.syncQueue.qos, DispatchQoS.default, "default constructor should have default priority")
+    }
+
+    func testPriorityAnyIsSet() {
+        // GIVEN
+        guard let expectedQoS = DispatchQoS.allCases.randomElement() else {
+            XCTFail("unexpected")
+            return
+        }
+
+        // WHEN
+        let dispatchGroup = TolerantDispatchGroup(qos: expectedQoS)
+
+        // THEN
+        XCTAssertNotNil(dispatchGroup)
+        XCTAssertEqual(dispatchGroup.syncQueue.qos, expectedQoS, "QoS should match")
     }
 }


### PR DESCRIPTION
### Abstract

`TolerantDispatchGroup` runs an internal GCD queue with a default QoS. 
When a higher QoS queue relies on `TolerantDispatchGroup,` we have a priority inversion.
We can now pass a QoS to the costructor of `TolerantDispatchGroup` in order to be coherent and prevent said priority inversion.

### Tasks

fix: Priority inversion could happend with TolerantDispatchGroup
test: Unit testing TolerantDispatchGroup QoS