### PR TITLE
feat: Allow returning complete api response

### DIFF
--- a/Sources/InfomaniakCore/Networking/ApiFetcher.swift
+++ b/Sources/InfomaniakCore/Networking/ApiFetcher.swift
@@ -32,7 +32,7 @@ open class ApiFetcher {
     enum ErrorDomain: Error {
         case noServerResponse
     }
-    
+
     public typealias RequestModifier = (inout URLRequest) throws -> Void
 
     /// All status except 401 are handled by our code, 401 status is handled by Alamofire's Authenticator code
@@ -140,10 +140,16 @@ open class ApiFetcher {
             )
     }
 
+    @available(*, deprecated, message: "Use perform with ValidServerResponse instead")
     open func perform<T: Decodable>(request: DataRequest,
                                     decoder: JSONDecoder = ApiFetcher.decoder) async throws -> (data: T, responseAt: Int?) {
         let validServerResponse: ValidServerResponse<T> = try await perform(request: request, decoder: decoder)
         return (validServerResponse.validApiResponse.data, validServerResponse.validApiResponse.responseAt)
+    }
+
+    open func perform<T: Decodable>(request: DataRequest,
+                                    decoder: JSONDecoder = ApiFetcher.decoder) async throws -> T {
+        return try await perform(request: request, decoder: decoder).validApiResponse.data
     }
 
     open func perform<T: Decodable>(request: DataRequest,

--- a/Sources/InfomaniakCore/Networking/ValidApiResponse.swift
+++ b/Sources/InfomaniakCore/Networking/ValidApiResponse.swift
@@ -1,0 +1,34 @@
+/*
+ Infomaniak Core - iOS
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Alamofire
+
+public struct ValidServerResponse<ValidApiResponseContent> {
+    public let responseHeaders: HTTPHeaders
+    public let validApiResponse: ValidApiResponse<ValidApiResponseContent>
+}
+
+public struct ValidApiResponse<ResponseContent> {
+    public let result: ApiResult
+    public let data: ResponseContent
+    public let total: Int?
+    public let pages: Int?
+    public let page: Int?
+    public let itemsPerPage: Int?
+    public let responseAt: Int?
+}

--- a/Tests/InfomaniakCoreTests/UTDecodeApiResponse.swift
+++ b/Tests/InfomaniakCoreTests/UTDecodeApiResponse.swift
@@ -16,11 +16,23 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@testable import Alamofire
 @testable import InfomaniakCore
 import XCTest
 
 @available(iOS 13.0, *)
 final class UTDecodeApiResponse: XCTestCase {
+    func fakeDataResponse<T: Decodable>(decodedResponse: ApiResponse<T>) -> DataResponse<ApiResponse<T>, AFError> {
+        DataResponse(
+            request: nil,
+            response: HTTPURLResponse(),
+            data: nil,
+            metrics: nil,
+            serializationDuration: 0,
+            result: .success(decodedResponse)
+        )
+    }
+
     func testDecodeNullDataResponse() throws {
         // GIVEN
         let apiFetcher = ApiFetcher()
@@ -33,12 +45,12 @@ final class UTDecodeApiResponse: XCTestCase {
 
         // WHEN
         let decodedResponse = try? JSONDecoder().decode(ApiResponse<NullableResponse>.self, from: jsonData)
+        let dataResponse = fakeDataResponse(decodedResponse: decodedResponse!)
 
         // THEN
         XCTAssertNotNil(decodedResponse, "Response shouldn't be nil")
         XCTAssertNoThrow(
-            try apiFetcher.handleApiResponse(decodedResponse!, responseStatusCode: 0),
-            "handleApiResponse shouldn't throw"
+            try apiFetcher.handleApiResponse(dataResponse), "handleApiResponse shouldn't throw"
         )
     }
 
@@ -54,13 +66,11 @@ final class UTDecodeApiResponse: XCTestCase {
 
         // WHEN
         let decodedResponse = try? JSONDecoder().decode(ApiResponse<Int>.self, from: jsonData)
+        let dataResponse = fakeDataResponse(decodedResponse: decodedResponse!)
 
         // THEN
         XCTAssertNotNil(decodedResponse, "Response shouldn't be nil")
-        XCTAssertNoThrow(
-            try apiFetcher.handleApiResponse(decodedResponse!, responseStatusCode: 0),
-            "handleApiResponse shouldn't throw"
-        )
+        XCTAssertNoThrow(try apiFetcher.handleApiResponse(dataResponse), "handleApiResponse shouldn't throw")
     }
 
     func testDecodeErrorNullApiResponse() throws {
@@ -74,11 +84,12 @@ final class UTDecodeApiResponse: XCTestCase {
 
         // WHEN
         let decodedResponse = try? JSONDecoder().decode(ApiResponse<Int>.self, from: jsonData)
+        let dataResponse = fakeDataResponse(decodedResponse: decodedResponse!)
 
         // THEN
         XCTAssertNotNil(decodedResponse, "Response shouldn't be nil")
         do {
-            let _ = try apiFetcher.handleApiResponse(decodedResponse!, responseStatusCode: 0)
+            let _ = try apiFetcher.handleApiResponse(dataResponse)
         } catch {
             let ikError = error as? InfomaniakError
             XCTAssertNotNil(ikError, "Error should be InfomaniakError")
@@ -97,11 +108,12 @@ final class UTDecodeApiResponse: XCTestCase {
 
         // WHEN
         let decodedResponse = try? JSONDecoder().decode(ApiResponse<Int>.self, from: jsonData)
+        let dataResponse = fakeDataResponse(decodedResponse: decodedResponse!)
 
         // THEN
         XCTAssertNotNil(decodedResponse, "Response shouldn't be nil")
         do {
-            let _ = try apiFetcher.handleApiResponse(decodedResponse!, responseStatusCode: 0)
+            let _ = try apiFetcher.handleApiResponse(dataResponse)
         } catch {
             let ikError = error as? InfomaniakError
             XCTAssertNotNil(ikError, "Error should be InfomaniakError")
@@ -123,11 +135,12 @@ final class UTDecodeApiResponse: XCTestCase {
 
         // WHEN
         let decodedResponse = try? JSONDecoder().decode(ApiResponse<Int>.self, from: jsonData)
+        let dataResponse = fakeDataResponse(decodedResponse: decodedResponse!)
 
         // THEN
         XCTAssertNotNil(decodedResponse, "Response shouldn't be nil")
         do {
-            let _ = try apiFetcher.handleApiResponse(decodedResponse!, responseStatusCode: 0)
+            let _ = try apiFetcher.handleApiResponse(dataResponse)
         } catch {
             let ikError = error as? InfomaniakError
             XCTAssertNotNil(ikError, "Error should be InfomaniakError")


### PR DESCRIPTION
It is marked as breaking because `handleApiResponse` signature changed and method is marked `open`. 
I checked both kDrive and kMail and handleApiResponse isn't used so it shouldn't be an issue. 

You can now either use:
`perform -> ValidServerResponse<T>` which returns a `ValidApiResponse` + `HTTPHeaders`
Or use the old "shortcut" 
`perform -> T` 

To get the old `responseAt` , use `perform().validApiResponse.responseAt`