### PR TITLE
fix: Prevent double group.enter() in ExpiringActivity

### DIFF
--- a/Sources/InfomaniakCore/SuddenTermination/ExpiringActivity.swift
+++ b/Sources/InfomaniakCore/SuddenTermination/ExpiringActivity.swift
@@ -109,6 +109,11 @@ public final class ExpiringActivity: ExpiringActivityable {
             if shouldTerminate {
                 self.shouldTerminate = true
                 delegate?.backgroundActivityExpiring()
+                
+                // At this point we should release the block, but we prefer to wait until the end 🫡⛵️🪦
+                // There is a chance endAll() is called while we wait in should terminate
+                group.wait()
+                return
             }
 
             group.enter()


### PR DESCRIPTION
Reused code [from a bugfix for kDrive](https://github.com/Infomaniak/ios-kDrive/pull/1197), to bring the fix for Mail and Drive post APIV3.