### PR TITLE
fix: Remove remaining explicit snake case coding keys

### DIFF
--- a/Sources/InfomaniakCore/Account/Account.swift
+++ b/Sources/InfomaniakCore/Account/Account.swift
@@ -43,11 +43,6 @@ open class Account: Codable {
         token = apiToken
         userId = apiToken.userId
     }
-
-    enum CodingKeys: CodingKey {
-        case userId
-        case user
-    }
 }
 
 extension Account: Equatable {

--- a/Sources/InfomaniakCore/Networking/ApiError.swift
+++ b/Sources/InfomaniakCore/Networking/ApiError.swift
@@ -27,11 +27,6 @@ public enum InfomaniakError: Error {
 @objc public class LoginApiError: NSObject, Codable {
     @objc public let error: String
     @objc public let errorDescription: String?
-
-    enum CodingKeys: String, CodingKey {
-        case error
-        case errorDescription
-    }
 }
 
 open class ApiError: Codable, Error {

--- a/Sources/InfomaniakCore/Networking/ApiError.swift
+++ b/Sources/InfomaniakCore/Networking/ApiError.swift
@@ -30,7 +30,7 @@ public enum InfomaniakError: Error {
 
     enum CodingKeys: String, CodingKey {
         case error
-        case errorDescription = "error_description"
+        case errorDescription
     }
 }
 

--- a/Sources/InfomaniakCore/Networking/ApiResponse.swift
+++ b/Sources/InfomaniakCore/Networking/ApiResponse.swift
@@ -46,10 +46,10 @@ open class ApiResponse<ResponseContent: Decodable>: Decodable {
         case total
         case pages
         case page
-        case itemsPerPage = "items_per_page"
-        case responseAt = "response_at"
+        case itemsPerPage
+        case responseAt
         case cursor
-        case hasMore = "has_more"
+        case hasMore
     }
 
     public required init(from decoder: Decoder) throws {


### PR DESCRIPTION
Made changes in `ApiResponse` and `ApiError`.
I'll check it does not break mail _and_ drive before we merge this.