### PR TITLE
feat(ApiFetcher): Custom decoder

### DIFF
--- a/Sources/InfomaniakCore/Networking/AbstractNetworkRequest.swift
+++ b/Sources/InfomaniakCore/Networking/AbstractNetworkRequest.swift
@@ -20,7 +20,7 @@ import Alamofire
 import Foundation
 
 /// Wrapping HTTP POST and GET parameters in this type
-public typealias Parameters = [String: any Any & Sendable]
+public typealias Parameters = [String: any Encodable & Sendable]
 
 /// Wrapping the body of an HTTP Request with common types
 public enum RequestBody {
@@ -67,7 +67,7 @@ struct BodyDataEncoding: ParameterEncoding {
     }
 
     func encode(_ urlRequest: URLRequestConvertible,
-                with parameters: Parameters?) throws -> URLRequest {
+                with parameters: Alamofire.Parameters?) throws -> URLRequest {
         var request = try urlRequest.asURLRequest()
         request.httpBody = data
         return request

--- a/Sources/InfomaniakCore/Networking/AbstractNetworkRequest.swift
+++ b/Sources/InfomaniakCore/Networking/AbstractNetworkRequest.swift
@@ -19,12 +19,9 @@
 import Alamofire
 import Foundation
 
-/// Wrapping HTTP POST and GET parameters in this type
-public typealias Parameters = [String: any Encodable & Sendable]
-
 /// Wrapping the body of an HTTP Request with common types
 public enum RequestBody {
-    case POSTParameters(Parameters)
+    case POSTParameters(EncodableParameters)
     case requestBody(Data)
 }
 
@@ -34,7 +31,7 @@ public protocol Requestable {
 
     var route: Endpoint { get set }
 
-    var GETParameters: Parameters? { get set }
+    var GETParameters: EncodableParameters? { get set }
 
     var body: RequestBody? { get set }
 }
@@ -75,7 +72,7 @@ struct BodyDataEncoding: ParameterEncoding {
 }
 
 public struct Request: Requestable {
-    public init(method: Method, route: InfomaniakCore.Endpoint, GETParameters: Parameters?, body: RequestBody?) {
+    public init(method: Method, route: InfomaniakCore.Endpoint, GETParameters: EncodableParameters?, body: RequestBody?) {
         self.method = method
         self.route = route
         self.GETParameters = GETParameters
@@ -86,7 +83,7 @@ public struct Request: Requestable {
 
     public var route: InfomaniakCore.Endpoint
 
-    public var GETParameters: Parameters?
+    public var GETParameters: EncodableParameters?
 
     public var body: RequestBody?
 }

--- a/Sources/InfomaniakCore/Networking/ApiFetcher+Dispatch.swift
+++ b/Sources/InfomaniakCore/Networking/ApiFetcher+Dispatch.swift
@@ -62,7 +62,7 @@ extension ApiFetcher: RequestDispatchable {
             request = authenticatedRequest(endpoint,
                                            method: method,
                                            parameters: nil,
-                                           encoding: BodyDataEncoding(data: data),
+                                           overrideEncoding: BodyDataEncoding(data: data),
                                            headers: headers)
         case .none:
             request = authenticatedRequest(endpoint,

--- a/Sources/InfomaniakCore/Networking/ApiFetcher+Dispatch.swift
+++ b/Sources/InfomaniakCore/Networking/ApiFetcher+Dispatch.swift
@@ -54,18 +54,18 @@ extension ApiFetcher: RequestDispatchable {
         let method = requestable.method.alamofireMethod
         switch body {
         case .POSTParameters(let parameters):
-            request = authenticatedRequest(endpoint,
+            request = try authenticatedRequest(endpoint,
                                            method: method,
                                            parameters: parameters)
         case .requestBody(let data):
             let headers: HTTPHeaders = [Self.contentType: Self.octetStream]
-            request = authenticatedRequest(endpoint,
-                                           method: method,
-                                           parameters: nil,
-                                           overrideEncoding: BodyDataEncoding(data: data),
-                                           headers: headers)
+            request = authenticatedSession.request(endpoint.url,
+                                                   method: method,
+                                                   parameters: nil,
+                                                   encoding: BodyDataEncoding(data: data),
+                                                   headers: headers)
         case .none:
-            request = authenticatedRequest(endpoint,
+            request = try authenticatedRequest(endpoint,
                                            method: method,
                                            parameters: nil)
         }

--- a/Sources/InfomaniakCore/Networking/ApiFetcher+Dispatch.swift
+++ b/Sources/InfomaniakCore/Networking/ApiFetcher+Dispatch.swift
@@ -54,7 +54,7 @@ extension ApiFetcher: RequestDispatchable {
         let method = requestable.method.alamofireMethod
         switch body {
         case .POSTParameters(let parameters):
-            request = try authenticatedRequest(endpoint,
+            request = authenticatedRequest(endpoint,
                                            method: method,
                                            parameters: parameters)
         case .requestBody(let data):
@@ -65,7 +65,7 @@ extension ApiFetcher: RequestDispatchable {
                                                    encoding: BodyDataEncoding(data: data),
                                                    headers: headers)
         case .none:
-            request = try authenticatedRequest(endpoint,
+            request = authenticatedRequest(endpoint,
                                            method: method,
                                            parameters: nil)
         }

--- a/Sources/InfomaniakCore/Networking/ApiFetcher.swift
+++ b/Sources/InfomaniakCore/Networking/ApiFetcher.swift
@@ -22,7 +22,7 @@ import InfomaniakDI
 import InfomaniakLogin
 import Sentry
 
-public typealias EncodableParameters = [String: any Encodable & Sendable]
+public typealias EncodableParameters = [String: Encodable & Sendable]
 
 public protocol RefreshTokenDelegate: AnyObject {
     func didUpdateToken(newToken: ApiToken, oldToken: ApiToken)
@@ -184,10 +184,10 @@ open class ApiFetcher {
                                     overrideDecoder: JSONDecoder? = nil) async throws -> ValidServerResponse<T> {
         let validatedRequest = request.validate(statusCode: ApiFetcher.handledHttpStatus)
 
-        let decoder = overrideDecoder ?? decoder
+        let requestDecoder = overrideDecoder ?? decoder
         let dataResponse = await validatedRequest.serializingDecodable(ApiResponse<T>.self,
                                                                        automaticallyCancelling: true,
-                                                                       decoder: decoder).response
+                                                                       decoder: requestDecoder).response
 
         SentryDebug.httpResponseBreadcrumb(urlRequest: request.convertible.urlRequest, urlResponse: dataResponse.response)
 

--- a/Sources/InfomaniakCore/Networking/ApiFetcher.swift
+++ b/Sources/InfomaniakCore/Networking/ApiFetcher.swift
@@ -47,8 +47,8 @@ open class ApiFetcher {
 
     public var authenticatedSession: Session!
 
-    private let decoder: JSONDecoder
-    private let bodyEncoder: JSONEncoder
+    public let decoder: JSONDecoder
+    public let bodyEncoder: JSONEncoder
 
     private let jsonParameterEncoder: JSONParameterEncoder
 

--- a/Sources/InfomaniakCore/Networking/ApiFetcher.swift
+++ b/Sources/InfomaniakCore/Networking/ApiFetcher.swift
@@ -22,6 +22,8 @@ import InfomaniakDI
 import InfomaniakLogin
 import Sentry
 
+public typealias EncodableParameters = [String: any Encodable & Sendable]
+
 public protocol RefreshTokenDelegate: AnyObject {
     func didUpdateToken(newToken: ApiToken, oldToken: ApiToken)
     func didFailRefreshToken(_ token: ApiToken)
@@ -135,7 +137,7 @@ open class ApiFetcher {
 
     public func authenticatedRequest(_ endpoint: Endpoint,
                                      method: HTTPMethod = .get,
-                                     parameters: [String: Encodable]? = nil,
+                                     parameters: EncodableParameters? = nil,
                                      overrideEncoder: ParameterEncoder? = nil,
                                      headers: HTTPHeaders? = nil,
                                      requestModifier: RequestModifier? = nil) -> DataRequest {

--- a/Sources/InfomaniakCore/Networking/EncodableDictionary.swift
+++ b/Sources/InfomaniakCore/Networking/EncodableDictionary.swift
@@ -18,10 +18,10 @@
 
 import Foundation
 
-struct EncodableDictionary: Encodable {
-    private let dictionary: [String: Encodable]
+struct EncodableDictionary: Encodable, Sendable {
+    private let dictionary: [String: Encodable & Sendable]
 
-    init(_ dictionary: [String: Encodable]) {
+    init(_ dictionary: [String: Encodable & Sendable]) {
         self.dictionary = dictionary
     }
 

--- a/Sources/InfomaniakCore/Networking/EncodableDictionary.swift
+++ b/Sources/InfomaniakCore/Networking/EncodableDictionary.swift
@@ -1,0 +1,47 @@
+/*
+ Infomaniak Core - iOS
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+struct EncodableDictionary: Encodable {
+    private let dictionary: [String: Encodable]
+
+    init(_ dictionary: [String: Encodable]) {
+        self.dictionary = dictionary
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        for (key, value) in dictionary {
+            try container.encode(value, forKey: CodingKeys(stringValue: key))
+        }
+    }
+
+    private struct CodingKeys: CodingKey {
+        var stringValue: String
+        var intValue: Int? { return nil }
+
+        init(stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        init?(intValue: Int) {
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
This is breaking. PRs are ready for mail and kDrive once this is merged.

- Remove global static decoder for ApiFetcher.
- Add the option to pass a custom decoder on ApiFetcher init
- Add the option to pass a custom encoder on ApiFetcher init for body params encoding
- To prevent too much breaking changes, you still have the option to also provide a custom decoder when calling `perform` for individual request but it has been renamed to `overrideDecoder` instead of `decoder`