### PR TITLE
fix: Remove `super.start` to avoid thread crash

### DIFF
--- a/Sources/InfomaniakCore/Asynchronous/AsynchronousOperation.swift
+++ b/Sources/InfomaniakCore/Asynchronous/AsynchronousOperation.swift
@@ -82,8 +82,6 @@ open class AsynchronousOperation: Operation {
     let asyncAwaitQueue = TaskQueue()
 
     override public final func start() {
-        super.start()
-
         if isCancelled {
             finish()
             return


### PR DESCRIPTION
https://developer.apple.com/library/mac/documentation/Cocoa/Reference/NSOperation_class/#//apple_ref/c/tdef/NSOperationQueuePriority

```
At no time in your [start()](https://developer.apple.com/documentation/foundation/operation/start()) method should you ever call super. When you define a concurrent operation, you take it upon yourself to provide the same behavior that the default [start()](https://developer.apple.com/documentation/foundation/operation/start()) method provides, which includes starting the task and generating the appropriate KVO notifications. Your [start()](https://developer.apple.com/documentation/foundation/operation/start()) method should also check to see if the operation itself was cancelled before actually starting the task. For more information about cancellation semantics, see [Responding to the Cancel Command](https://developer.apple.com/documentation/foundation/operation#Responding-to-the-Cancel-Command).
```
